### PR TITLE
CIS Gauntlet initiative

### DIFF
--- a/data/pilots/separatist-alliance/gauntlet-fighter.json
+++ b/data/pilots/separatist-alliance/gauntlet-fighter.json
@@ -136,7 +136,7 @@
       "image": "https://infinitearenas.com/xw2/images/pilots/deathwatchwarrior.png",
       "cost": 6,
       "loadout": 20,
-      "initiative": 1,
+      "initiative": 2,
       "limited": 0,
       "standard": true,
       "extended": true,


### PR DESCRIPTION
Death Watch Warrior changed to i2 instead of i1.