### PR TITLE
Fixed image and artwork links

### DIFF
--- a/data/pilots/galactic-empire/tie-ph-phantom.json
+++ b/data/pilots/galactic-empire/tie-ph-phantom.json
@@ -197,7 +197,7 @@
         "stygiumreserve-tiephphantom"
       ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/whisper-tiephphantom.png",
-      "artwork": "",
+      "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/whisper-tiephphantom.png",
       "standard": true,
       "extended": true,
       "epic": true,
@@ -224,8 +224,8 @@
         "stealthgambit-tiephphantom",
         "manualailerons-tiephphantom"
       ],
-      "image": "https://infinitearenas.com/xw2/images/quickbuilds/whisper-tiephphantom.png",
-      "artwork": "https://infinitearenas.com/xw2/images/quickbuilds/echo-tiephphantom.png",
+      "image": "https://infinitearenas.com/xw2/images/quickbuilds/echo-tiephphantom.png",
+      "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/echo-tiephphantom.png",
       "standard": true,
       "extended": true,
       "epic": true,


### PR DESCRIPTION
Echo and Whisper standard loadouts had incorrect or incomplete image and artwork links.