### PR TITLE
Correct XWS for Rebel Han Solo Gunner

### DIFF
--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -303,7 +303,7 @@
     "uid": "URB1044",
     "name": "Han Solo",
     "limited": 1,
-    "xws": "hansolo-rebel",
+    "xws": "hansolo",
     "sides": [
       {
         "title": "Han Solo",


### PR DESCRIPTION
Rebel Han Solo gunner XWS is "hansolo" while the Scum Han Solo gunner was added later and was appended "hansolo-gunner"