### PR TITLE
Add missing force.side to 15 Force pilots

### DIFF
--- a/data/pilots/galactic-empire/tie-d-defender.json
+++ b/data/pilots/galactic-empire/tie-d-defender.json
@@ -292,7 +292,10 @@
       "extended": true,
       "force": {
         "value": 3,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "dark"
+        ]
       },
       "cost": 22,
       "loadout": 14,

--- a/data/pilots/galactic-empire/tie-in-interceptor.json
+++ b/data/pilots/galactic-empire/tie-in-interceptor.json
@@ -661,7 +661,10 @@
       "ability": "While you perform an attack, after the Neutralize Results step, if the attack hit, you may spend 2 [Force]. If you do, change all of your [Hit] results to [Critical Hit] results.",
       "force": {
         "value": 2,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "dark"
+        ]
       },
       "keywords": [
         "Dark Side",

--- a/data/pilots/galactic-republic/eta-2-actis.json
+++ b/data/pilots/galactic-republic/eta-2-actis.json
@@ -125,7 +125,10 @@
       "extended": true,
       "force": {
         "value": 3,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "light"
+        ]
       },
       "ability": "After you or a friendly Anakin Skywalker ship at range 0-3 executes a maneuver, if there are more enemy ships than other friendly ships at range 0-1 of that ship, you may spend 1 [Force]. If you do, that ship gains 1 focus token.",
       "cost": 11,
@@ -163,7 +166,10 @@
       "extended": true,
       "force": {
         "value": 2,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "light"
+        ]
       },
       "ability": "While an enemy ship in your [Front Arc] at range 0-1 performs an attack, the defender may change 1 blank result to a [Focus] result.",
       "cost": 11,
@@ -201,7 +207,10 @@
       "extended": true,
       "force": {
         "value": 2,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "light"
+        ]
       },
       "ability": "At the start of the End Phase, you may spend any number of [Force] to choose that many friendly ships at range 0-2. Each chosen ship does not remove 1 focus or evade token during this End Phase.",
       "cost": 11,
@@ -239,7 +248,10 @@
       "extended": true,
       "force": {
         "value": 2,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "light"
+        ]
       },
       "cost": 10,
       "loadout": 9,
@@ -275,7 +287,10 @@
       "extended": true,
       "force": {
         "value": 3,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "light"
+        ]
       },
       "ability": "After another friendly ship at range 0-3 spends 1 or more [Force], you may spend 1 [Force]. If you do, that ship recovers 1 [Force].",
       "cost": 10,
@@ -313,7 +328,11 @@
       "ability": "After you or a friendly Obi-Wan Kenobi ship at range 0-3 fully executes a maneuver, if there are more enemy ships than other friendly ships at range 0-1 of that ship, you may spend 1 [Force]. If you do, that ship may perform a [Barrel Roll] action.",
       "force": {
         "value": 3,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "dark",
+          "light"
+        ]
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/anakinskywalker-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/anakinskywalker-eta2actis.png",
@@ -350,7 +369,10 @@
       "ability": "After you or a friendly Anakin Skywalker at range 0-3 fully executes a maneuver, if there are more enemy ships than other friendly ships at range 0-1 of that ship, you may spend 1 [Force]. If you do, that ship may perform a [Boost] action.",
       "force": {
         "value": 3,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "light"
+        ]
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/obiwankenobi-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/obiwankenobi-eta2actis.png",
@@ -386,7 +408,10 @@
       "ability": "At the start of the End Phase, you may perfrom a purple [Coordinate] action, even while stressed. After you perform a [Coordinate] action, if the chosen ship has the Born for This ship ability, you may coordinate 1 additional ship.",
       "force": {
         "value": 2,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "light"
+        ]
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/shaakti-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/shaakti.png",
@@ -423,7 +448,10 @@
       "extended": true,
       "force": {
         "value": 2,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "light"
+        ]
       },
       "ability": "While another friendly ship defends, if the attacker is in its [Bullseye Arc], you may spend 1 [Force] to change 1 of the defender's blank results to a [Focus] result.",
       "cost": 10,

--- a/data/pilots/rebel-alliance/rz-1-a-wing.json
+++ b/data/pilots/rebel-alliance/rz-1-a-wing.json
@@ -303,7 +303,10 @@
       "extended": true,
       "force": {
         "value": 3,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "light"
+        ]
       },
       "cost": 12,
       "loadout": 12,
@@ -405,7 +408,10 @@
       "loadout": 15,
       "force": {
         "value": 1,
-        "recovers": 0
+        "recovers": 0,
+        "side": [
+          "light"
+        ]
       },
       "slots": [
         "Modification",

--- a/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
+++ b/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
@@ -237,7 +237,10 @@
       ],
       "force": {
         "value": 1,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "light"
+        ]
       },
       "cost": 9,
       "loadout": 7,

--- a/data/pilots/separatist-alliance/firespray-class-patrol-craft.json
+++ b/data/pilots/separatist-alliance/firespray-class-patrol-craft.json
@@ -206,7 +206,10 @@
       "ability": "Before you engage, you may spend 1 [Force] to choose 2 enemy ships at range 0-1. Transfer any number of orange and red tokens between those two ships.",
       "force": {
         "value": 1,
-        "recovers": 1
+        "recovers": 1,
+        "side": [
+          "dark"
+        ]
       },
       "cost": 17,
       "loadout": 10,


### PR DESCRIPTION
15 pilots have force.value but no force.side, so builders that gate Force powers by side hide them for these pilots (we hit this with Roiling Anger on Darth Vader, TIE/D Defender).

- dark: darthvader-tieddefender, secondsister, aurrasing
- light: ahsokatano-rz1awing, keovenzee, kananjarrus-hwk290lightfreighter, obiwankenobi-eta2actis, aaylasecura, shaakti, jedigeneral, yoda, kitfisto, obiwankenobi-siegeofcoruscant, shaakti-siegeofcoruscant
- both: anakinskywalker-siegeofcoruscant (matches his Dark Side + Light Side keywords, same shape as Kylo on the Whisper interceptor)

Sides taken from each pilot's own Light Side / Dark Side keywords; Keo Venzee has no side keyword so that one is from the printed card.